### PR TITLE
chore: add max width to container for ultrawide monitors

### DIFF
--- a/style.css
+++ b/style.css
@@ -25,6 +25,9 @@ body {
 
 .container {
   padding: 1.875rem 1.75rem;
+
+  margin: 0 auto;
+  max-width: 1280px;
 }
 
 a {
@@ -70,9 +73,11 @@ header {
   padding: 1rem 7.25rem;
 
   background: rgb(18, 18, 18);
-  background: linear-gradient(45deg,
-      rgba(18, 18, 18, 1) 30%,
-      rgba(36, 121, 64, 0.5) 80%);
+  background: linear-gradient(
+    45deg,
+    rgba(18, 18, 18, 1) 30%,
+    rgba(36, 121, 64, 0.5) 80%
+  );
 }
 
 header h1 {


### PR DESCRIPTION
Many website layouts aren't optimized for being viewed with Ultrawide monitors, because their contents can fill all the viewport length, sharding the information all over the screen and making the F pattern harder to read.
![image](https://user-images.githubusercontent.com/47110995/224454337-c2ecac23-5847-4d82-868d-a12964aab573.png)

By adding a simple `max-width` and `margin: 0 auto`, the layout and content becomes more readable on ultrawide screens:
![image](https://user-images.githubusercontent.com/47110995/224454541-0378aefb-6e80-4429-9ce0-4d6d2954f1d3.png)
